### PR TITLE
Voeg privacybeleid map5topo app toe

### DIFF
--- a/docs/src/app/privacy.md
+++ b/docs/src/app/privacy.md
@@ -1,0 +1,66 @@
+---
+title: Privacybeleid map5topo app
+---
+
+Just Objects BV, gevestigd aan:
+
+> van der Hoochlaan 3  
+> 1181 PL Amstelveen  
+> Nederland
+
+is verantwoordelijk voor de verwerking van persoonsgegevens zoals weergegeven in deze privacyverklaring.
+
+**Contactgegevens:**
+
+> https://justobjects.nl/  
+> van der Hoochlaan 3  
+> 1181 PL Amstelveen  
+> Nederland
+
+
+**Persoonsgegevens die wij verwerken**
+
+Just Objects BV verwerkt je persoonsgegevens doordat je gebruik maakt van onze diensten en/of omdat je deze gegevens zelf aan ons verstrekt.
+
+Hieronder vind je een overzicht van de persoonsgegevens die wij verwerken:
+
+- IP-adres
+- Locatiegegevens (als je de kaart van je huidige locatie opvraagt)
+
+**Bijzondere en/of gevoelige persoonsgegevens die wij verwerken**
+
+Onze website en/of dienst heeft niet de intentie gegevens te verzamelen over websitebezoekers die jonger zijn dan 16 jaar. Tenzij ze toestemming hebben van ouders of voogd. We kunnen echter niet controleren of een bezoeker ouder dan 16 is. Wij raden ouders dan ook aan betrokken te zijn bij de online activiteiten van hun kinderen, om zo te voorkomen dat er gegevens over kinderen verzameld worden zonder ouderlijke toestemming. Als je er van overtuigd bent dat wij zonder die toestemming persoonlijke gegevens hebben verzameld over een minderjarige, neem dan contact met ons op via support@map5.nl, dan verwijderen wij deze informatie.
+
+**Just Objects BV verwerkt jouw persoonsgegevens voor de volgende doelen:**
+
+- Om goederen en diensten bij je af te leveren.
+- Het bewaken en verbeteren van de technische werking en beschikbaarheid van de kaartapplicatie.
+- Misbruikdetectie
+
+**Hoe lang we persoonsgegevens bewaren**
+
+Just Objects BV bewaart je persoonsgegevens niet langer dan strikt nodig is om de doelen te realiseren waarvoor je gegevens worden verzameld. Wij hanteren de volgende bewaartermijnen voor de volgende (categorieën) van persoonsgegevens:
+
+- IP-adres: maximaal een jaar
+
+**Delen van persoonsgegevens met derden**
+
+Just Objects BV verstrekt uitsluitend aan derden en alleen als dit nodig is voor de uitvoering van onze overeenkomst met jou of om te voldoen aan een wettelijke verplichting.
+
+**Cookies, of vergelijkbare technieken, die wij gebruiken**
+
+Just Objects BV gebruikt alleen technische en functionele cookies. En analytische cookies die geen inbreuk maken op je privacy. Een cookie is een klein tekstbestand dat bij het eerste bezoek aan deze website wordt opgeslagen op jouw computer, tablet of smartphone. De cookies die wij gebruiken zijn noodzakelijk voor de technische werking van de website en jouw gebruiksgemak. Ze zorgen ervoor dat de website naar behoren werkt en onthouden bijvoorbeeld jouw voorkeursinstellingen. Ook kunnen wij hiermee onze website optimaliseren. Je kunt je afmelden voor cookies door je internetbrowser zo in te stellen dat deze geen cookies meer opslaat. Daarnaast kun je ook alle informatie die eerder is opgeslagen via de instellingen van je browser verwijderen.
+
+**Gegevens inzien, aanpassen of verwijderen**
+
+Je hebt het recht om je persoonsgegevens in te zien, te corrigeren of te verwijderen. Daarnaast heb je het recht om je eventuele toestemming voor de gegevensverwerking in te trekken of bezwaar te maken tegen de verwerking van jouw persoonsgegevens door Just Objects BV en heb je het recht op gegevensoverdraagbaarheid. Dat betekent dat je bij ons een verzoek kan indienen om de persoonsgegevens die wij van jou beschikken in een computerbestand naar jou of een ander, door jou genoemde organisatie, te sturen. 
+
+Je kunt een verzoek tot inzage, correctie, verwijdering, gegevensoverdraging van je persoonsgegevens of verzoek tot intrekking van je toestemming of bezwaar op de verwerking van jouw persoonsgegevens sturen naar support@map5.nl.
+
+Om er zeker van te zijn dat het verzoek tot inzage door jou is gedaan, vragen wij jou een kopie van je identiteitsbewijs met het verzoek mee te sturen. Maak in deze kopie je pasfoto, MRZ (machine readable zone, de strook met nummers onderaan het paspoort), paspoortnummer en Burgerservicenummer (BSN) zwart. Dit ter bescherming van je privacy. We reageren zo snel mogelijk, maar binnen vier weken, op jouw verzoek.
+
+Just Objects BV wil je er tevens op wijzen dat je de mogelijkheid hebt om een klacht in te dienen bij de nationale toezichthouder, de Autoriteit Persoonsgegevens. Dat kan via de volgende link: https://autoriteitpersoonsgegevens.nl/nl/contact-met-de-autoriteit-persoonsgegevens/tip-ons
+
+**Hoe wij persoonsgegevens beveiligen**
+
+Just Objects BV neemt de bescherming van jouw gegevens serieus en neemt passende maatregelen om misbruik, verlies, onbevoegde toegang, ongewenste openbaarmaking en ongeoorloofde wijziging tegen te gaan. Als jij het idee hebt dat jouw gegevens toch niet goed beveiligd zijn of er aanwijzingen zijn van misbruik, neem dan contact op met onze helpdesk via support@map5.nl

--- a/docs/src/app/privacy.md
+++ b/docs/src/app/privacy.md
@@ -33,7 +33,7 @@ Onze website en/of dienst heeft niet de intentie gegevens te verzamelen over web
 
 **Just Objects BV verwerkt jouw persoonsgegevens voor de volgende doelen:**
 
-- Om goederen en diensten bij je af te leveren.
+- Om op basis van je actuele of gekozen locatie, kaarten van betreffend gebied bij je af te leveren.
 - Het bewaken en verbeteren van de technische werking en beschikbaarheid van de kaartapplicatie.
 - Misbruikdetectie
 


### PR DESCRIPTION
Op basis van privacyverklaring-generator van de overheid https://veiliginternetten.nl/privacyverklaring-generator/

Ik heb hem niet aan het menu toegevoegd maar de link komt op de app-store pagina.